### PR TITLE
A few things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,10 @@
 language: rust
-rust: nightly
+rust:
+  - nightly
+  - beta
+  - stable
+
+matrix:
+  allow_failures:
+    - rust: nightly
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coinbaser"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Patrick Moriarty <pataroose@gmail.com>"]
 description = "Coinbase Exchange API for Rust."
 documentation = "http://patrickjm.github.io/doc/coinbaser/coinbaser/"

--- a/src/coinbaser.rs
+++ b/src/coinbaser.rs
@@ -8,7 +8,6 @@ use hyper::client::Client;
 use hyper::header::{Headers, UserAgent};
 use hyper::status::StatusCode;
 use hyper::Url;
-use rustc_serialize::{Decodable};
 use uuid::Uuid;
 
 pub const DEFAULT_ENDPOINT: &'static str = "https://api.exchange.coinbase.com";
@@ -162,7 +161,6 @@ pub struct OrderBook {
 }
 
 mod dummy_orderbook {
-	use rustc_serialize::Decodable;
 	use super::{Price, Order, OrderBook};
 	use uuid::{ParseError, Uuid};
 	#[derive(Debug, PartialEq, RustcDecodable)]
@@ -288,7 +286,6 @@ pub struct Trade {
 
 mod dummy_trade {
 	use chrono::{DateTime, UTC, ParseError};
-	use rustc_serialize::Decodable;
 	use super::{Price, Trade, TradeSide};
 
 	#[derive(Debug, RustcDecodable)]
@@ -327,7 +324,6 @@ pub struct HistoricRate {
 
 mod dummy_historic {
 	use chrono::{DateTime, UTC, ParseError};
-	use rustc_serialize::Decodable;
 	use super::{Price, HistoricRate};
 
 	#[derive(Debug, RustcDecodable)]
@@ -373,7 +369,7 @@ pub struct Currency {
 }
 
 pub fn tester() {
-	use rustc_serialize::{json, Decoder};
+	use rustc_serialize::json;
 
 	println!("{}/currencies", DEFAULT_ENDPOINT);
 	let down = http_get(&format!("{}/currencies", DEFAULT_ENDPOINT), "hyper/0.6.0/coinbaser");


### PR DESCRIPTION
Hey there, came across your crate based on the last crater report: https://internals.rust-lang.org/t/new-crater-reports-1-1-stable-vs-beta-2015-07-10-and-nightly-2015-07-10/2358

It seems like you've since fixed the build, but uploading a fixed version to crates.io would be nice. So I've updated to a 0.2.0 for you, and while I was here, did two other things:

1. Fixed some unused imports warnings. There are still some other warnings, but they're based on 'never used' and as you continue to develop the crate, I'm guessing you'll use them, so leaving them for now.
2. Your crate builds just fine on stable, so I've added a Travis config that builds on all three for you. Since nightly breaks all the time, I set it up to _not_ break your build, but maybe you want that, and if so, we can just remove the exclusion from the build matrix.